### PR TITLE
Officer template should default to PO

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -126,7 +126,7 @@ class AddOfficerForm(Form):
                          validators=[AnyOf(allowed_values(GENDER_CHOICES))])
     star_no = StringField('Badge Number', default='', validators=[
         Regexp('\w*'), Length(max=50)])
-    rank = SelectField('Rank', default='COMMANDER', choices=RANK_CHOICES,
+    rank = SelectField('Rank', default='PO', choices=RANK_CHOICES,
                        validators=[AnyOf(allowed_values(RANK_CHOICES))])
     unit = QuerySelectField('Unit', validators=[Optional()],
                             query_factory=unit_choices, get_label='descrip',


### PR DESCRIPTION
Add New officer template should default to PO

## Status

Ready for review / in progress

## Description of Changes

Fixes # .

Changes proposed in this pull request:

 - 
 - 
 - 

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [ ] I have rebased my changes on current `develop`
 
 [ ] pytests pass in the development environment on my local machine
 
 [ ] `flake8` checks pass
